### PR TITLE
imx7d: filter out over maximum frequency of the CPU in device tree

### DIFF
--- a/include/configs/pico-imx7d.h
+++ b/include/configs/pico-imx7d.h
@@ -34,6 +34,7 @@
 #include "imx6_spl.h"
 #endif
 
+#define CONFIG_OF_SYSTEM_SETUP
 /* Size of malloc() pool */
 #define CONFIG_SYS_MALLOC_LEN           (32 * SZ_1M)
 


### PR DESCRIPTION
i.mx7d has two kinds of variants to support maximum speed grade: 1Ghz and 1.2Ghz.
This patch avoids to set 1Ghz type of i.mx7d operates at 1.2Ghz.
Patch from Ray.